### PR TITLE
반복 일정 모듈에 대한 웹 서버를 구현한다

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -37,8 +37,8 @@ post "/evts" do
 end
 
 get "/evts" do
-  req_hash = {
-    :evt_arg => Recur::Event.new('', params[:evt_arg]),
+  req = {
+    :evt_arg => Recur::Event.new(params[:evt_arg]),
     :date => Date.new(*params[:date].split("-").map(&:to_i))
   }
 

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -17,25 +17,19 @@ end
 
 # 반복 이벤트를 추가한다
 post "/evts" do
-  req = JSON.parse request.body.read
-  req_hash = {
-    :desc => req['desc'],
-    :recur_type => req['recur_type'],
-    :day_idx => req['recur_params']['day_idx'],
-    :cnt => req['recur_params']['cnt']
-  }
+  req = JSON.parse(request.body.read, symbolize_names: true)
   scd = Recur::Schedule.new
 
   tmpr_expr = nil
-  case req_hash[:recur_type]
+  case req[:recur_type]
   when "DayInMonth"
-    day_idx = req_hash[:day_idx].to_i
-    cnt = req_hash[:cnt].to_i
+    day_idx = req[:recur_params][:day_idx].to_i
+    cnt = req[:recur_params][:cnt].to_i
     tmpr_expr = Recur::DayInMonth.new(day_idx, cnt)
   end
 
   scd.add_elem Recur::ScheduleElem.new(
-    Recur::Event.new("", req_hash[:desc]),
+    Recur::Event.new("", req[:desc]),
     tmpr_expr
   )
   rec = session[:rec] || Recurring.new

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -32,9 +32,10 @@ post "/evts" do
     Recur::Event.new("", req[:desc]),
     tmpr_expr
   )
-  rec = session[:rec] || Recurring.new
-  rec.add_schedule scd
-  session[:rec] = Marshal.dump(rec)
+
+  recur = session[:recur] || Recurring.new
+  recur.add_schedule scd
+  session[:recur] = Marshal.dump(recur)
 end
 
 get "/evts" do
@@ -43,7 +44,7 @@ get "/evts" do
     :date => Date.new(*params[:date].split("-").map(&:to_i))
   }
 
-  rec_in_session = Marshal.load(session[:rec])
+  rec_in_session = Marshal.load(session[:recur])
   rec_in_session.schedules.each do |scd|
     if scd.is_occurring req_hash[:evt_arg], req_hash[:date]
       return {

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -22,9 +22,7 @@ post "/evts" do
   tmpr_expr = nil
   case req[:recur_type]
   when "DayInMonth"
-    day_idx = req[:recur_params][:day_idx].to_i
-    cnt = req[:recur_params][:cnt].to_i
-    tmpr_expr = Recur::DayInMonth.new(day_idx, cnt)
+    tmpr_expr = Recur::DayInMonth.new(*req[:recur_params].values.map(&:to_i))
   end
 
   scd = Recur::Schedule.new

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -42,15 +42,16 @@ get "/evts" do
     :date => Date.new(*params[:date].split("-").map(&:to_i))
   }
 
-  rec_in_session = Marshal.load(session[:recur])
-  rec_in_session.schedules.each do |scd|
-    if scd.is_occurring req_hash[:evt_arg], req_hash[:date]
+  recur_in_session = Marshal.load(session[:recur])
+  recur_in_session.schedules.each do |scd|
+    if scd.is_occurring req[:evt_arg], req[:date]
       return {
-        :desc => "#{req_hash[:evt_arg]} occurs on #{req_hash[:date].to_s}"
+        :desc => "#{req[:evt_arg].desc} occurs on #{req[:date].to_s}"
       }.to_json
     end
   end
+
   {
-    :desc => "#{req_hash[:evt_arg].desc} not occurs on #{req_hash[:date].to_s}"
+    :desc => "#{req[:evt_arg].desc} not occurs on #{req[:date].to_s}"
   }.to_json
 end

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,6 +1,7 @@
 require "sinatra"
 require "json"
 require "date"
+require "pp"
 
 require_relative "recurring"
 require_relative "./recurring/event"

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -18,7 +18,6 @@ end
 # 반복 이벤트를 추가한다
 post "/evts" do
   req = JSON.parse(request.body.read, symbolize_names: true)
-  scd = Recur::Schedule.new
 
   tmpr_expr = nil
   case req[:recur_type]
@@ -28,6 +27,7 @@ post "/evts" do
     tmpr_expr = Recur::DayInMonth.new(day_idx, cnt)
   end
 
+  scd = Recur::Schedule.new
   scd.add_elem Recur::ScheduleElem.new(
     Recur::Event.new("", req[:desc]),
     tmpr_expr

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -8,6 +8,8 @@ require_relative "./recurring/schedule_elem"
 require_relative "./recurring/tmpr_expr/temporal_expr"
 require_relative "./recurring/tmpr_expr/day_in_month"
 
+enable :sessions
+
 before do
   content_type :json
 end
@@ -21,7 +23,6 @@ post "/evts" do
     :day_idx => req['recur_params']['day_idx'],
     :cnt => req['recur_params']['cnt']
   }
-  rec = Recurring.new
   scd = Recur::Schedule.new
 
   tmpr_expr = nil
@@ -36,5 +37,9 @@ post "/evts" do
     Recur::Event.new("", req_hash[:desc]),
     tmpr_expr
   )
+  rec = session[:rec] || Recurring.new
   rec.add_schedule scd
+  session[:rec] = Marshal.dump(rec)
+end
+
 end

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,0 +1,40 @@
+require "sinatra"
+require "json"
+
+require_relative "recurring"
+require_relative "./recurring/event"
+require_relative "./recurring/schedule"
+require_relative "./recurring/schedule_elem"
+require_relative "./recurring/tmpr_expr/temporal_expr"
+require_relative "./recurring/tmpr_expr/day_in_month"
+
+before do
+  content_type :json
+end
+
+# 반복 이벤트를 추가한다
+post "/evts" do
+  req = JSON.parse request.body.read
+  req_hash = {
+    :desc => req['desc'],
+    :recur_type => req['recur_type'],
+    :day_idx => req['recur_params']['day_idx'],
+    :cnt => req['recur_params']['cnt']
+  }
+  rec = Recurring.new
+  scd = Recur::Schedule.new
+
+  tmpr_expr = nil
+  case req_hash[:recur_type]
+  when "DayInMonth"
+    day_idx = req_hash[:day_idx].to_i
+    cnt = req_hash[:cnt].to_i
+    tmpr_expr = Recur::DayInMonth.new(day_idx, cnt)
+  end
+
+  scd.add_elem Recur::ScheduleElem.new(
+    Recur::Event.new("", req_hash[:desc]),
+    tmpr_expr
+  )
+  rec.add_schedule scd
+end

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,5 +1,6 @@
 require "sinatra"
 require "json"
+require "date"
 
 require_relative "recurring"
 require_relative "./recurring/event"
@@ -42,4 +43,21 @@ post "/evts" do
   session[:rec] = Marshal.dump(rec)
 end
 
+get "/evts" do
+  req_hash = {
+    :evt_arg => Recur::Event.new('', params[:evt_arg]),
+    :date => Date.new(*params[:date].split("-").map(&:to_i))
+  }
+
+  rec_in_session = Marshal.load(session[:rec])
+  rec_in_session.schedules.each do |scd|
+    if scd.is_occurring req_hash[:evt_arg], req_hash[:date]
+      return {
+        :desc => "#{req_hash[:evt_arg]} occurs on #{req_hash[:date].to_s}"
+      }.to_json
+    end
+  end
+  {
+    :desc => "#{req_hash[:evt_arg].desc} not occurs on #{req_hash[:date].to_s}"
+  }.to_json
 end

--- a/lib/recurring.rb
+++ b/lib/recurring.rb
@@ -1,13 +1,13 @@
 require_relative "./recurring/schedule"
 
 class Recurring
-  attr_reader :schedule
+  attr_reader :schedules
 
   def initialize
-    @schedule = []
+    @schedules = []
   end
 
   def add_schedule scd
-    @schedule << scd
+    @schedules << scd
   end
 end

--- a/lib/recurring.rb
+++ b/lib/recurring.rb
@@ -1,0 +1,13 @@
+require_relative "./recurring/schedule"
+
+class Recurring
+  attr_reader :schedule
+
+  def initialize
+    @schedule = []
+  end
+
+  def add_schedule scd
+    @schedule << scd
+  end
+end

--- a/lib/recurring/event.rb
+++ b/lib/recurring/event.rb
@@ -2,7 +2,7 @@ module Recur
   class Event
     attr_reader :occurrences, :desc
 
-    def initialize ocrs, desc
+    def initialize ocrs = "", desc
       @occurrences = conv2dates(ocrs)
       @desc = desc
     end

--- a/req/.curl
+++ b/req/.curl
@@ -1,0 +1,10 @@
+curl -X POST --location "http://localhost:4567/evt" \
+       -H "Content-Type: application/json" \
+       -d '{
+         "desc": "golf games",
+           "recur_type": "DayInMonth",
+           "recur_params": {
+             "day_idx": 1,
+             "cnt": 1
+           }
+       }'

--- a/req/.http
+++ b/req/.http
@@ -12,4 +12,4 @@ Content-Type: application/json
 }
 
 ###
-GET http://localhost:4567/evt
+GET http://localhost:4567/evts?evt_arg=golf games&date=2024-12-12

--- a/req/.http
+++ b/req/.http
@@ -1,0 +1,15 @@
+###
+POST http://localhost:4567/evt
+Content-Type: application/json
+
+{
+  "desc": "golf games",
+  "recur_type": "DayInMonth",
+  "recur_params": {
+    "day_idx": 1,
+    "cnt": 0
+  }
+}
+
+###
+GET http://localhost:4567/evt

--- a/req/.http
+++ b/req/.http
@@ -13,3 +13,5 @@ Content-Type: application/json
 
 ###
 GET http://localhost:4567/evts?evt_arg=golf games&date=2024-12-12
+###
+GET http://localhost:4567/evts?evt_arg=golf games&date=2024-12-2

--- a/req/.http
+++ b/req/.http
@@ -1,5 +1,5 @@
 ###
-POST http://localhost:4567/evt
+POST http://localhost:4567/evts
 Content-Type: application/json
 
 {
@@ -7,7 +7,7 @@ Content-Type: application/json
   "recur_type": "DayInMonth",
   "recur_params": {
     "day_idx": 1,
-    "cnt": 0
+    "cnt": 1
   }
 }
 


### PR DESCRIPTION
- sinatra 기반으로 반복 일정 추가 및 일정 관련 연산을 요청할 수 있는 웹 서버 초기 구현
  - 반복 일정 등록 post 메서드
  - 등록된 반복 일정 중 {이벤트명, 날짜}에 매칭되는 반복 일정이 있는지 확인하는 get 메서드
- 동일한 세션 내에서 일어나는 상태 변화를 유지한다
  - db 없이 post 요청으로 등록한 반복 일정을 동일한 세션의 이후 요청에서 접근할 수 있게 하기 위해서
  - post 요청을 보냈을 때 등록한 반복 일정을 세션 데이터에 직렬화(Marshal.dump)해서 저장한다
  - 이후 동일한 세션에서 get 요청을 받았을 때, 세션에서 가지고 있는 직렬화된 반복 일정 데이터를
  역직렬화(Marshal.load)해서 요청을 처리한다
- 구현하면서 생긴 불필요한 로직 정리