### PR TITLE
반복 일정 등록 api 응답값을 고친다

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -35,6 +35,7 @@ post "/evts" do
   recur = session[:recur] || Recurring.new
   recur.add_schedule scd
   session[:recur] = Marshal.dump(recur)
+  {"evt_name" => req[:desc]}.to_json
 end
 
 get "/evts" do

--- a/req/.curl
+++ b/req/.curl
@@ -1,4 +1,4 @@
-curl -X POST --location "http://localhost:4567/evt" \
+curl -X POST --location "http://localhost:4567/evts" \
        -H "Content-Type: application/json" \
        -d '{
          "desc": "golf games",


### PR DESCRIPTION
- https://github.com/rogarithm/notify-event/ 에서 구현하는 spring 서버에서 본 프로젝트의 ruby+sinatra 서버에 반복 일정 등록 요청을 할 수 있도록 한다
- api 응답값을 spring 서버에서 제대로 처리하지 못하는 문제를 해결한다